### PR TITLE
Modify/mkptree

### DIFF
--- a/command/executor.go
+++ b/command/executor.go
@@ -24,10 +24,10 @@ func (c *CommandExecutor) TransferBalance(wsv model.ObjectFinder, cmd model.Comm
 	transfer := cmd.GetTransferBalance()
 	srcAccount := c.factory.NewEmptyAccount()
 	destAccount := c.factory.NewEmptyAccount()
-	if err := wsv.Query(cmd.GetTargetId(), srcAccount); err != nil {
+	if err := wsv.Query(model.MustAddress(cmd.GetTargetId()), srcAccount); err != nil {
 		return errors.Wrap(core.ErrCommandExecutorTransferBalanceNotFoundSrcAccountId, err.Error())
 	}
-	if err := wsv.Query(transfer.GetDestAccountId(), destAccount); err != nil {
+	if err := wsv.Query(model.MustAddress(transfer.GetDestAccountId()), destAccount); err != nil {
 		return errors.Wrap(core.ErrCommandExecutorTransferBalanceNotFoundDestAccountId, err.Error())
 	}
 	if srcAccount.GetBalance()-transfer.GetBalance() < 0 {
@@ -46,10 +46,10 @@ func (c *CommandExecutor) TransferBalance(wsv model.ObjectFinder, cmd model.Comm
 		destAccount.GetPublicKeys(),
 		destAccount.GetBalance()+transfer.GetBalance(),
 	)
-	if err := wsv.Append(newSrcAccount.GetAccountId(), newSrcAccount); err != nil {
+	if err := wsv.Append(model.MustAddress(newSrcAccount.GetAccountId()), newSrcAccount); err != nil {
 		return err
 	}
-	if err := wsv.Append(newDestAccount.GetAccountId(), newDestAccount); err != nil {
+	if err := wsv.Append(model.MustAddress(newDestAccount.GetAccountId()), newDestAccount); err != nil {
 		return err
 	}
 	return nil
@@ -58,13 +58,13 @@ func (c *CommandExecutor) TransferBalance(wsv model.ObjectFinder, cmd model.Comm
 func (c *CommandExecutor) CreateAccount(wsv model.ObjectFinder, cmd model.Command) error {
 	newAccount := c.factory.NewAccount(cmd.GetTargetId(), cmd.GetTargetId(), make([]model.PublicKey, 0), 0)
 	ac := c.factory.NewEmptyAccount()
-	if err := wsv.Query(cmd.GetTargetId(), ac); err == nil {
+	if err := wsv.Query(model.MustAddress(cmd.GetTargetId()), ac); err == nil {
 		if ac.GetAccountId() == cmd.GetTargetId() {
 			return errors.Wrap(core.ErrCommandExecutorCreateAccountAlreadyExistAccount,
 				fmt.Errorf("already exist accountId : %s", cmd.GetTargetId()).Error())
 		}
 	}
-	if err := wsv.Append(cmd.GetTargetId(), newAccount); err != nil {
+	if err := wsv.Append(model.MustAddress(cmd.GetTargetId()), newAccount); err != nil {
 		return err
 	}
 	return nil
@@ -73,7 +73,7 @@ func (c *CommandExecutor) CreateAccount(wsv model.ObjectFinder, cmd model.Comman
 func (c *CommandExecutor) AddBalance(wsv model.ObjectFinder, cmd model.Command) error {
 	aa := cmd.GetAddBalance()
 	ac := c.factory.NewEmptyAccount()
-	if err := wsv.Query(cmd.GetTargetId(), ac); err != nil {
+	if err := wsv.Query(model.MustAddress(cmd.GetTargetId()), ac); err != nil {
 		return errors.Wrapf(core.ErrCommandExecutorAddBalanceNotExistAccount, err.Error())
 	}
 	if ac.GetAccountId() != cmd.GetTargetId() {
@@ -85,7 +85,7 @@ func (c *CommandExecutor) AddBalance(wsv model.ObjectFinder, cmd model.Command) 
 		ac.GetPublicKeys(),
 		ac.GetBalance()+aa.GetBalance(),
 	)
-	if err := wsv.Append(newAc.GetAccountId(), newAc); err != nil {
+	if err := wsv.Append(model.MustAddress(newAc.GetAccountId()), newAc); err != nil {
 		return err
 	}
 	return nil
@@ -103,7 +103,7 @@ func containsPublicKey(keys []model.PublicKey, key model.PublicKey) bool {
 func (c *CommandExecutor) AddPublicKeys(wsv model.ObjectFinder, cmd model.Command) error {
 	ap := cmd.GetAddPublicKeys()
 	ac := c.factory.NewEmptyAccount()
-	if err := wsv.Query(cmd.GetTargetId(), ac); err != nil {
+	if err := wsv.Query(model.MustAddress(cmd.GetTargetId()), ac); err != nil {
 		return errors.Wrapf(core.ErrCommandExecutorAddPublicKeyNotExistAccount, err.Error())
 	}
 	if ac.GetAccountId() != cmd.GetTargetId() {
@@ -119,7 +119,7 @@ func (c *CommandExecutor) AddPublicKeys(wsv model.ObjectFinder, cmd model.Comman
 		append(ac.GetPublicKeys(), ap.GetPublicKeys()[0]),
 		ac.GetBalance(),
 	)
-	if err := wsv.Append(newAc.GetAccountId(), newAc); err != nil {
+	if err := wsv.Append(model.MustAddress(newAc.GetAccountId()), newAc); err != nil {
 		return err
 	}
 	return nil

--- a/command/executor_test.go
+++ b/command/executor_test.go
@@ -93,7 +93,7 @@ func TestCommandExecutor_CreateAccount(t *testing.T) {
 				assert.NoError(t, err)
 
 				ac := fc.NewEmptyAccount()
-				err = wsv.Query(c.exTargetId, ac)
+				err = wsv.Query(model.MustAddress(c.exTargetId), ac)
 				require.NoError(t, err)
 				assert.Equal(t, c.exTargetId, ac.GetAccountId())
 				assert.Equal(t, int64(0), ac.GetBalance())
@@ -112,8 +112,8 @@ func TestCommandExecutor_AddBalance(t *testing.T) {
 		name           string
 		exAuthoirzerId string
 		exTargetId     string
-		addBalance      int64
-		exBalance       int64
+		addBalance     int64
+		exBalance      int64
 		exErr          error
 	}{
 		{
@@ -167,7 +167,7 @@ func TestCommandExecutor_AddBalance(t *testing.T) {
 				assert.NoError(t, err)
 
 				ac := fc.NewEmptyAccount()
-				err = wsv.Query(c.exTargetId, ac)
+				err = wsv.Query(model.MustAddress(c.exTargetId), ac)
 				require.NoError(t, err)
 				assert.Equal(t, c.exTargetId, ac.GetAccountId())
 				assert.Equal(t, c.exBalance, ac.GetBalance())
@@ -188,9 +188,9 @@ func TestCommandExecutor_TransferBalance(t *testing.T) {
 		exAuthoirzerId  string
 		exTargetId      string
 		exDestAccountId string
-		transBalance     int64
-		exSrcBalance     int64
-		exDestBalance    int64
+		transBalance    int64
+		exSrcBalance    int64
+		exDestBalance   int64
 		exErr           error
 	}{
 		{
@@ -250,7 +250,7 @@ func TestCommandExecutor_TransferBalance(t *testing.T) {
 					Command: &proskenion.Command_TransferBalance{
 						TransferBalance: &proskenion.TransferBalance{
 							DestAccountId: c.exDestAccountId,
-							Balance:        c.transBalance,
+							Balance:       c.transBalance,
 						},
 					},
 					TargetId:     c.exTargetId,
@@ -263,14 +263,14 @@ func TestCommandExecutor_TransferBalance(t *testing.T) {
 				assert.NoError(t, err)
 
 				srcAc := fc.NewEmptyAccount()
-				err = wsv.Query(c.exTargetId, srcAc)
+				err = wsv.Query(model.MustAddress(c.exTargetId), srcAc)
 				require.NoError(t, err)
 				assert.Equal(t, c.exTargetId, srcAc.GetAccountId())
 				assert.Equal(t, c.exSrcBalance, srcAc.GetBalance())
 				assert.Equal(t, make([]model.PublicKey, 0), srcAc.GetPublicKeys())
 
 				destAc := fc.NewEmptyAccount()
-				err = wsv.Query(c.exDestAccountId, destAc)
+				err = wsv.Query(model.MustAddress(c.exDestAccountId), destAc)
 				require.NoError(t, err)
 				assert.Equal(t, c.exDestAccountId, destAc.GetAccountId())
 				assert.Equal(t, c.exDestBalance, destAc.GetBalance())
@@ -367,7 +367,7 @@ func TestCommandExecutor_AddPublicKey(t *testing.T) {
 				assert.NoError(t, err)
 
 				ac := fc.NewEmptyAccount()
-				err = wsv.Query(c.targetId, ac)
+				err = wsv.Query(model.MustAddress(c.targetId), ac)
 				require.NoError(t, err)
 				assert.Equal(t, c.targetId, ac.GetAccountId())
 				assert.ElementsMatch(t, c.exKeys, ac.GetPublicKeys())

--- a/command/validator.go
+++ b/command/validator.go
@@ -56,7 +56,11 @@ func (c *CommandValidator) Tx(wsv model.ObjectFinder, txh model.TxFinder, tx mod
 	}
 	for _, cmd := range tx.GetPayload().GetCommands() {
 		ac := c.fc.NewEmptyAccount()
-		err := wsv.Query(cmd.GetAuthorizerId(), ac)
+		authorizerId, err := model.NewAddress(cmd.GetAuthorizerId())
+		if err != nil {
+			return err // TODO ErrAddressParse
+		}
+		err = wsv.Query(authorizerId, ac)
 		if err != nil {
 			return errors.Wrapf(core.ErrTxValidateNotFoundAuthorizer,
 				"authorizer : %s", cmd.GetAuthorizerId())

--- a/convertor/peer.go
+++ b/convertor/peer.go
@@ -1,1 +1,0 @@
-package convertor

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -17,3 +17,7 @@ type Modelor interface {
 	Unmarshaler
 	Hasher
 }
+
+type UnmarshalerFactory interface {
+	CreateUnmarshaler() Unmarshaler
+}

--- a/core/model/object.go
+++ b/core/model/object.go
@@ -49,3 +49,16 @@ type Object interface {
 	GetDict() map[string]Object
 	Modelor
 }
+
+type Address struct {
+	storage string
+	domain  string
+	account string
+}
+
+func NewAddress(id string) {
+
+}
+
+func (a Address) Get() {
+}

--- a/core/model/object.go
+++ b/core/model/object.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"fmt"
+	"github.com/proskenion/proskenion/regexp"
+)
+
 type ObjectCode int
 
 const (
@@ -56,9 +61,27 @@ type Address struct {
 	account string
 }
 
-func NewAddress(id string) {
-
+func NewAddress(id string) (*Address, error) {
+	if regexp.GetRegexp().VerifyWalletId.MatchString(id) ||
+		regexp.GetRegexp().VerifyAccountId.MatchString(id) ||
+		regexp.GetRegexp().VerifyDomainId.MatchString(id) ||
+		regexp.GetRegexp().VerifyStorageId.MatchString(id) {
+		ret := regexp.GetRegexp().SplitAddress.FindStringSubmatch(id)
+		return &Address{
+			ret[3],
+			ret[2],
+			ret[1],
+		}, nil
+	}
+	return nil, fmt.Errorf("Failed Parse Address not correct format: %s", id)
 }
 
-func (a Address) Get() {
+const dividedChar = "\\"
+
+func (a *Address) GetBytes() []byte {
+	ret := make([]byte, 2)
+	for _, c := range a.storage + dividedChar + a.domain + dividedChar + a.account {
+		ret = append(ret, byte(c))
+	}
+	return ret
 }

--- a/core/model/repository.go
+++ b/core/model/repository.go
@@ -2,9 +2,11 @@ package model
 
 type ObjectFinder interface {
 	// Query gets value from targetId
-	Query(targetId string, value Unmarshaler) error
+	Query(targetId Address, value Unmarshaler) error
+	// Query All gets value from fromId
+	QueryAll(fromId Address, value UnmarshalerFactory) ([]Unmarshaler, error)
 	// Append [targetId] = value
-	Append(targetId string, value Marshaler) error
+	Append(targetId Address, value Marshaler) error
 }
 
 type TxFinder interface {

--- a/core/repository.go
+++ b/core/repository.go
@@ -82,11 +82,13 @@ type MerklePatriciaNodeIterator interface {
 type WSV interface {
 	Hasher
 	// Query gets value from targetId
-	Query(targetId string, value Unmarshaler) error
+	Query(targetId Address, value Unmarshaler) error
+	// Query All gets value from fromId
+	QueryAll(fromId Address, value UnmarshalerFactory) ([]Unmarshaler, error)
 	// Get PeerService
-	PeerService() (PeerService, error)
+	PeerService(peerRootId Address) (PeerService, error)
 	// Append [targetId] = value
-	Append(targetId string, value Marshaler) error
+	Append(targetId Address, value Marshaler) error
 	// Commit appenging nodes
 	Commit() error
 	// RollBack

--- a/core/repository.go
+++ b/core/repository.go
@@ -6,14 +6,15 @@ import (
 )
 
 var (
-	ErrMerklePatriciaTreeNotFoundKey = errors.Errorf("Failed MerklePatriciaTree Not Found key")
-	ErrInvalidKVNodes                = errors.Errorf("Failed Key Value Nodes Invalid")
-	ErrWSVNotFound                   = errors.Errorf("Failed WSV Query Not Found")
-	ErrWSVQueryUnmarshal             = errors.Errorf("Failed WSV Query Unmarshal")
-	ErrTxHistoryNotFound             = errors.Errorf("Failed TxHistory Query Not Found")
-	ErrTxHistoryQueryUnmarshal       = errors.Errorf("Failed TxHistory Query Unmarshal")
-	ErrBlockchainNotFound            = errors.Errorf("Failed Blockchain Get Not Found")
-	ErrBlockchainQueryUnmarshal      = errors.Errorf("Failed Blocchain Get Unmarshal")
+	ErrMerklePatriciaTreeNotSearchKey = errors.Errorf("Failed MerklePatriciaTree can not search key")
+	ErrMerklePatriciaTreeNotFoundKey  = errors.Errorf("Failed MerklePatriciaTree Not Found key")
+	ErrInvalidKVNodes                 = errors.Errorf("Failed Key Value Nodes Invalid")
+	ErrWSVNotFound                    = errors.Errorf("Failed WSV Query Not Found")
+	ErrWSVQueryUnmarshal              = errors.Errorf("Failed WSV Query Unmarshal")
+	ErrTxHistoryNotFound              = errors.Errorf("Failed TxHistory Query Not Found")
+	ErrTxHistoryQueryUnmarshal        = errors.Errorf("Failed TxHistory Query Unmarshal")
+	ErrBlockchainNotFound             = errors.Errorf("Failed Blockchain Get Not Found")
+	ErrBlockchainQueryUnmarshal       = errors.Errorf("Failed Blocchain Get Unmarshal")
 )
 
 var (
@@ -45,7 +46,9 @@ type KVNode interface {
 
 // Merkle Patricia Tree に対する操作
 type MerklePatriciaController interface {
-	// key で参照した先の iterator を取得
+	// key と prefix が一致している最も浅い internal iterator を取得
+	Search(key []byte) (MerklePatriciaNodeIterator, error)
+	// key で参照した先の leaf iterator を取得
 	Find(key []byte) (MerklePatriciaNodeIterator, error)
 	// Upsert したあとの Iterator を生成して取得
 	Upsert(KVNode) (MerklePatriciaNodeIterator, error)

--- a/query/processor.go
+++ b/query/processor.go
@@ -43,7 +43,7 @@ func (q *QueryProcessor) Query(query model.Query) (model.QueryResponse, error) {
 
 	// 署名チェック
 	ac := q.fc.NewEmptyAccount()
-	err = wsv.Query(query.GetPayload().GetAuthorizerId(), ac)
+	err = wsv.Query(model.MustAddress(query.GetPayload().GetAuthorizerId()), ac)
 	if err != nil {
 		return nil, errors.Wrapf(core.ErrQueryProcessorNotExistAuthoirizer,
 			"authorizer : %s", query.GetPayload().GetAuthorizerId())
@@ -72,7 +72,7 @@ func (q *QueryProcessor) Query(query model.Query) (model.QueryResponse, error) {
 
 func (q *QueryProcessor) accountObjectQuery(qp model.QueryPayload, wsv core.WSV) (model.QueryResponse, error) {
 	ac := q.fc.NewEmptyAccount()
-	err := wsv.Query(qp.GetTargetId(), ac)
+	err := wsv.Query(model.MustAddress(qp.GetTargetId()), ac)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (q *QueryProcessor) accountObjectQuery(qp model.QueryPayload, wsv core.WSV)
 
 func (q *QueryProcessor) peerObjectQuery(qp model.QueryPayload, wsv core.WSV) (model.QueryResponse, error) {
 	peer := q.fc.NewEmptyPeer()
-	err := wsv.Query(qp.GetTargetId(), peer)
+	err := wsv.Query(model.MustAddress(qp.GetTargetId()), peer)
 	if err != nil {
 		return nil, err
 	}

--- a/regexp/regexp.go
+++ b/regexp/regexp.go
@@ -5,6 +5,10 @@ import "regexp"
 type Regexper struct {
 	VerifyAccountId   *regexp.Regexp
 	VerifyPeerAddress *regexp.Regexp
+	VerifyDomainId    *regexp.Regexp
+	VerifyStorageId   *regexp.Regexp
+	VerifyWalletId    *regexp.Regexp
+	SplitAddress      *regexp.Regexp
 }
 
 var instance *Regexper
@@ -14,6 +18,10 @@ func GetRegexp() *Regexper {
 		instance = &Regexper{
 			VerifyAccountId:   newVerifyAccountId(),
 			VerifyPeerAddress: newVerifyPeerAddress(),
+			VerifyDomainId:    newVerifyDomainId(),
+			VerifyStorageId:   newVerifyStorageId(),
+			VerifyWalletId:    newVerifyWalletId(),
+			SplitAddress:      newSplitAddress(),
 		}
 	}
 	return instance
@@ -25,4 +33,27 @@ func newVerifyAccountId() *regexp.Regexp {
 
 func newVerifyPeerAddress() *regexp.Regexp {
 	return regexp.MustCompile(`[a-z_0-9]{1,32}:\d{5}`)
+}
+
+////
+// accountId = "account@domain.com"
+// domainId = "domain.com"
+// storageId = "domain.com/storage"
+// walletId = "account@domain.com/storage"
+//
+
+func newVerifyDomainId() *regexp.Regexp {
+	return regexp.MustCompile(`^[a-z_0-9]{1,32}(\.[a-z_0-9]{1,32}){0,4}$`)
+}
+
+func newVerifyStorageId() *regexp.Regexp {
+	return regexp.MustCompile(`^[a-z_0-9]{1,32}(\.[a-z_0-9]{1,32}){0,4}/[a-z_0-9]{1,32}$`)
+}
+
+func newVerifyWalletId() *regexp.Regexp {
+	return regexp.MustCompile(`^[a-z_0-9]{1,32}\@[a-z_0-9]{1,32}(\.[a-z_0-9]{1,32}){0,4}/[a-z_0-9]{1,32}$`)
+}
+
+func newSplitAddress() *regexp.Regexp {
+	return regexp.MustCompile(`^(?:([a-z_0-9]{1,32})\@)?([a-z_0-9]{1,32}(?:\.[a-z_0-9]{1,32}){0,4})(?:/([a-z_0-9]{1,32}))?$`)
 }

--- a/regexp/regexp.go
+++ b/regexp/regexp.go
@@ -28,7 +28,7 @@ func GetRegexp() *Regexper {
 }
 
 func newVerifyAccountId() *regexp.Regexp {
-	return regexp.MustCompile(`^[a-z_0-9]{1,32}\@[a-z_0-9]{1,32}(\.[a-z_0-9]{1,32}){0,4}$`)
+	return regexp.MustCompile(`^[a-z_0-9]{1,32}\@([a-z_0-9]{1,32}(\.[a-z_0-9]{1,32}){0,4})?$`)
 }
 
 func newVerifyPeerAddress() *regexp.Regexp {
@@ -47,7 +47,7 @@ func newVerifyDomainId() *regexp.Regexp {
 }
 
 func newVerifyStorageId() *regexp.Regexp {
-	return regexp.MustCompile(`^[a-z_0-9]{1,32}(\.[a-z_0-9]{1,32}){0,4}/[a-z_0-9]{1,32}$`)
+	return regexp.MustCompile(`^([a-z_0-9]{1,32}(\.[a-z_0-9]{1,32}){0,4})?/[a-z_0-9]{1,32}$`)
 }
 
 func newVerifyWalletId() *regexp.Regexp {
@@ -55,5 +55,5 @@ func newVerifyWalletId() *regexp.Regexp {
 }
 
 func newSplitAddress() *regexp.Regexp {
-	return regexp.MustCompile(`^(?:([a-z_0-9]{1,32})\@)?([a-z_0-9]{1,32}(?:\.[a-z_0-9]{1,32}){0,4})(?:/([a-z_0-9]{1,32}))?$`)
+	return regexp.MustCompile(`^(?:([a-z_0-9]{1,32})\@)?([a-z_0-9]{1,32}(?:\.[a-z_0-9]{1,32}){0,4})?(?:/([a-z_0-9]{1,32}))?$`)
 }

--- a/regexp/regexp_test.go
+++ b/regexp/regexp_test.go
@@ -41,9 +41,9 @@ func TestVerifyAccountId(t *testing.T) {
 			false,
 		},
 		{
-			"case 5 no domain",
+			"case 5 correct no domain",
 			"account@",
-			false,
+			true,
 		},
 		{
 			"case 6 no accountt",
@@ -155,9 +155,9 @@ func TestNewVerifyStorageId(t *testing.T) {
 			false,
 		},
 		{
-			"case 4 no domain",
+			"case 4 correct no domain",
 			"/storage",
-			false,
+			true,
 		},
 		{
 			"case 5 no storage",
@@ -296,6 +296,27 @@ func TestNewSplitAddress(t *testing.T) {
 			"",
 			"domain.com.a.b",
 			"",
+		},
+		{
+			"case 7 no domain",
+			"account@/storage",
+			"storage",
+			"",
+			"account",
+		},
+		{
+			"case 8 only storage",
+			"/storage",
+			"storage",
+			"",
+			"",
+		},
+		{
+			"case 9 only account",
+			"ac@",
+			"",
+			"",
+			"ac",
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {

--- a/regexp/regexp_test.go
+++ b/regexp/regexp_test.go
@@ -70,3 +70,241 @@ func TestVerifyAccountId(t *testing.T) {
 		})
 	}
 }
+
+func TestNewVerifyDomainId(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		domainId string
+		ok       bool
+	}{
+		{
+			"case 1 correct",
+			"domain.com",
+			true,
+		},
+		{
+			"case 2 correct",
+			"domain.com.a.b.c",
+			true,
+		},
+		{
+			"case 3 correct",
+			"domain",
+			true,
+		},
+		{
+			"case 4 over domain",
+			"domain.com.a.b.c.d",
+			false,
+		},
+		{
+			"case 5 a little account",
+			"@",
+			false,
+		},
+		{
+			"case 6 no domain",
+			"account@",
+			false,
+		},
+		{
+			"case 7 accountId",
+			"account@domain.com",
+			false,
+		},
+		{
+			"case 8 over domain",
+			"adfsfsfsdfsadfdsfaasdfdsfsdfsdfsdfdsfsdffsfsdfsdf",
+			false,
+		},
+		{
+			"case 9 ng char",
+			"Dcom",
+			false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if c.ok {
+				assert.True(t, GetRegexp().VerifyDomainId.MatchString(c.domainId))
+			} else {
+				assert.False(t, GetRegexp().VerifyDomainId.MatchString(c.domainId))
+			}
+		})
+	}
+}
+
+func TestNewVerifyStorageId(t *testing.T) {
+	for _, c := range []struct {
+		name      string
+		storageId string
+		ok        bool
+	}{
+		{
+			"case 1 correct",
+			"domain.com/storage",
+			true,
+		},
+		{
+			"case 2 correct",
+			"domain.com.a.b.c/storage",
+			true,
+		},
+		{
+			"case 3 over domain",
+			"domain.com.a.b.c.d/storage",
+			false,
+		},
+		{
+			"case 4 no domain",
+			"/storage",
+			false,
+		},
+		{
+			"case 5 no storage",
+			"/",
+			false,
+		},
+		{
+			"case 6 over domain",
+			"adfsfsfsdfsadfdsfaasdfdsfsdfsdfsdfdsfsdffsfsdfsdf/a",
+			false,
+		},
+		{
+			"case 6 over storage",
+			"a/adfsfsfsdfsadfdsfaasdfdsfsdfsdfsdfdsfsdffsfsdfsdf",
+			false,
+		},
+		{
+			"case 8 ng char",
+			"dcom/Storage",
+			false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if c.ok {
+				assert.True(t, GetRegexp().VerifyStorageId.MatchString(c.storageId))
+			} else {
+				assert.False(t, GetRegexp().VerifyStorageId.MatchString(c.storageId))
+			}
+		})
+	}
+}
+
+func TestNewVerifyWalletId(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		walletId string
+		ok       bool
+	}{
+		{
+			"case 1 correct",
+			"accoun@domain.com/storage",
+			true,
+		},
+		{
+			"case 2 correct",
+			"account@domain.com.a.b.c/storage",
+			true,
+		},
+		{
+			"case 3 over domain",
+			"a@domain.com.a.b.c.d/storage",
+			false,
+		},
+		{
+			"case 4 no domain",
+			"a@/storage",
+			false,
+		},
+		{
+			"case 5 no storage",
+			"a@domain/",
+			false,
+		},
+		{
+			"case 6 over domain",
+			"a@adfsfsfsdfsadfdsfaasdfdsfsdfsdfsdfdsfsdffsfsdfsdf/a",
+			false,
+		},
+		{
+			"case 6 over storage",
+			"a@a/adfsfsfsdfsadfdsfaasdfdsfsdfsdfsdfdsfsdffsfsdfsdf",
+			false,
+		},
+		{
+			"case 8 ng char",
+			"a@dcom/Storage",
+			false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if c.ok {
+				assert.True(t, GetRegexp().VerifyWalletId.MatchString(c.walletId))
+			} else {
+				assert.False(t, GetRegexp().VerifyWalletId.MatchString(c.walletId))
+			}
+		})
+	}
+}
+
+func TestNewSplitAddress(t *testing.T) {
+	for _, c := range []struct {
+		name    string
+		id      string
+		storage string
+		domain  string
+		account string
+	}{
+		{
+			"case 1 all",
+			"account@domain.com/storage",
+			"storage",
+			"domain.com",
+			"account",
+		},
+		{
+			"case 2 correct",
+			"account@domain.com.a.b.c/storage",
+			"storage",
+			"domain.com.a.b.c",
+			"account",
+		},
+		{
+			"case 3 correct",
+			"a@domain/storage",
+			"storage",
+			"domain",
+			"a",
+		},
+		{
+			"case 4 no account",
+			"domain/storage",
+			"storage",
+			"domain",
+			"",
+		},
+		{
+			"case 5 no storage",
+			"a@domain",
+			"",
+			"domain",
+			"a",
+		},
+		{
+			"case 6 only domain",
+			"domain.com.a.b",
+			"",
+			"domain.com.a.b",
+			"",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			res := GetRegexp().SplitAddress.FindStringSubmatch(c.id)
+			assert.Equal(t, 4, len(res))
+			assert.Equal(t, c.id, res[0])
+			assert.Equal(t, c.account, res[1])
+			assert.Equal(t, c.domain, res[2])
+			assert.Equal(t, c.storage, res[3])
+		})
+	}
+}

--- a/repository/merkle_patricia_tree.go
+++ b/repository/merkle_patricia_tree.go
@@ -77,13 +77,21 @@ func (t *MerklePatriciaTree) Get(hash model.Hash) (core.MerklePatriciaNodeIterat
 }
 
 // key と prefix が一致している最も浅い internal iterator を取得
-func (t *MerklePatriciaTree) Search(key []byte) (MerklePatriciaNodeIterator, error) {
-	return t.Iterator().Search(key)
+func (t *MerklePatriciaTree) Search(key []byte) (core.MerklePatriciaNodeIterator, error) {
+	ret, err := t.Iterator().Search(key)
+	if err != nil {
+		return nil, errors.Wrap(core.ErrMerklePatriciaTreeNotSearchKey, err.Error())
+	}
+	return ret, nil
 }
 
 // key で参照した先の iterator を取得
 func (t *MerklePatriciaTree) Find(key []byte) (core.MerklePatriciaNodeIterator, error) {
-	return t.Iterator().Find(key)
+	ret, err := t.Iterator().Find(key)
+	if err != nil {
+		return nil, errors.Wrap(core.ErrMerklePatriciaTreeNotFoundKey, err.Error())
+	}
+	return ret, nil
 }
 
 // Upsert したあとの新しい Iterator を生成して取得

--- a/repository/merkle_patricia_tree_test.go
+++ b/repository/merkle_patricia_tree_test.go
@@ -25,7 +25,11 @@ func testUpsertFirst(t *testing.T, tree core.MerklePatriciaTree, node core.KVNod
 	err = it.Data(unmarshaler)
 	assert.NoError(t, err)
 	// use value is model.Account
-	assert.Equal(t, MustHash(node.Value().(model.Account)), MustHash(unmarshaler.(model.Account)))
+	assert.Equal(t, node.Value().(model.Account).Hash(), unmarshaler.(model.Account).Hash())
+
+	// search key
+	iti, err := tree.Search(node.Key())
+	assert.Equal(t, iti.DataHash(), it.Hash())
 }
 
 func testUpsertSecond(t *testing.T, tree core.MerklePatriciaTree, node core.KVNode, unmarshaler model.Unmarshaler) {
@@ -40,6 +44,10 @@ func testUpsertSecond(t *testing.T, tree core.MerklePatriciaTree, node core.KVNo
 	assert.NoError(t, err)
 	// use value is model.Account
 	assert.Equal(t, MustHash(node.Value().(model.Account)), MustHash(unmarshaler.(model.Account)))
+
+	// search key
+	iti, err := tree.Search(node.Key())
+	assert.Equal(t, iti.DataHash(), it.Hash())
 }
 
 func testMerklePatriciaTree(t *testing.T, tree1 core.MerklePatriciaTree, tree2 core.MerklePatriciaTree) {

--- a/repository/wsv.go
+++ b/repository/wsv.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/pkg/errors"
 	"github.com/proskenion/proskenion/convertor"
 	"github.com/proskenion/proskenion/core"
@@ -37,7 +36,7 @@ func (w *WSV) Hash() model.Hash {
 
 // targetId を MerklePatriciaTree の key バイト列に変換
 func makeWSVId(id model.Address) []byte {
-	ret := make([]byte,1)
+	ret := make([]byte, 1)
 	ret[0] = WSV_ROOT_KEY
 	return append(ret, id.GetBytes()...)
 }
@@ -79,7 +78,6 @@ func (w *WSV) QueryAll(fromId model.Address, ufc model.UnmarshalerFactory) ([]mo
 
 // PeerService gets value from targetId
 func (w *WSV) PeerService(peerRootId model.Address) (core.PeerService, error) {
-	fmt.Println("peerRoot: " ,makeWSVId(peerRootId))
 	peerRoot, err := w.tree.Search(makeWSVId(peerRootId))
 	if err != nil {
 		return nil, err
@@ -92,13 +90,11 @@ func (w *WSV) PeerService(peerRootId model.Address) (core.PeerService, error) {
 		}
 	}
 
-	fmt.Println("peerRoot Key()")
-	fmt.Println(peerRoot.Key())
 	leafs, err := peerRoot.SubLeafs()
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(len(leafs))
+
 	peers := make([]model.Peer, 0, len(leafs))
 	for _, leaf := range leafs {
 		peer := w.fc.NewEmptyPeer()
@@ -106,7 +102,6 @@ func (w *WSV) PeerService(peerRootId model.Address) (core.PeerService, error) {
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println(peer.GetAddress())
 		peers = append(peers, peer)
 	}
 	w.ps = NewPeerService(peers)
@@ -136,7 +131,6 @@ func (kv *KVNode) Next(cnt int) core.KVNode {
 
 // Append [targetId] = value
 func (w *WSV) Append(targetId model.Address, value model.Marshaler) error {
-	fmt.Println("append peerRoot: " ,makeWSVId(targetId))
 	_, err := w.tree.Upsert(&KVNode{makeWSVId(targetId), value})
 	return err
 }

--- a/repository/wsv.go
+++ b/repository/wsv.go
@@ -37,7 +37,9 @@ func (w *WSV) Hash() model.Hash {
 
 // targetId を MerklePatriciaTree の key バイト列に変換
 func makeWSVId(id model.Address) []byte {
-	return append([]byte{WSV_ROOT_KEY}, id.GetBytes()...)
+	ret := make([]byte,1)
+	ret[0] = WSV_ROOT_KEY
+	return append(ret, id.GetBytes()...)
 }
 
 // Query gets value from targetId
@@ -77,6 +79,7 @@ func (w *WSV) QueryAll(fromId model.Address, ufc model.UnmarshalerFactory) ([]mo
 
 // PeerService gets value from targetId
 func (w *WSV) PeerService(peerRootId model.Address) (core.PeerService, error) {
+	fmt.Println("peerRoot: " ,makeWSVId(peerRootId))
 	peerRoot, err := w.tree.Search(makeWSVId(peerRootId))
 	if err != nil {
 		return nil, err
@@ -133,6 +136,7 @@ func (kv *KVNode) Next(cnt int) core.KVNode {
 
 // Append [targetId] = value
 func (w *WSV) Append(targetId model.Address, value model.Marshaler) error {
+	fmt.Println("append peerRoot: " ,makeWSVId(targetId))
 	_, err := w.tree.Upsert(&KVNode{makeWSVId(targetId), value})
 	return err
 }

--- a/repository/wsv_test.go
+++ b/repository/wsv_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func test_WSV_Upserts(t *testing.T, wsv core.WSV, id string, ac model.Account) {
+func test_WSV_Upserts(t *testing.T, wsv core.WSV, id model.Address, ac model.Account) {
 	err := wsv.Query(id, ac)
 	require.EqualError(t, errors.Cause(err), core.ErrWSVNotFound.Error())
 	err = wsv.Append(id, ac)
@@ -24,7 +24,7 @@ func test_WSV_Upserts(t *testing.T, wsv core.WSV, id string, ac model.Account) {
 	assert.Equal(t, MustHash(ac), MustHash(unmarshaler))
 }
 
-func test_WSV_Upserts_Peer(t *testing.T, wsv core.WSV, id string, peer model.Peer) {
+func test_WSV_Upserts_Peer(t *testing.T, wsv core.WSV, id model.Address, peer model.Peer) {
 	err := wsv.Query(id, peer)
 	require.EqualError(t, errors.Cause(err), core.ErrWSVNotFound.Error())
 	err = wsv.Append(id, peer)
@@ -44,18 +44,19 @@ func test_WSV(t *testing.T, wsv core.WSV) {
 		RandomAccount(),
 		RandomAccount(),
 	}
-	ids := []string{
-		"targeta",
-		"tartb",
-		"tartbc",
-		"xyz",
-		"target",
+	ids := []model.Address{
+		model.MustAddress("targeta@a"),
+		model.MustAddress("tartb@a"),
+		model.MustAddress("tartbc@a"),
+		model.MustAddress("xyz@a"),
+		model.MustAddress("target@a"),
 	}
 
 	for i, ac := range acs {
 		test_WSV_Upserts(t, wsv, ids[i], ac)
 	}
-	_, err := wsv.PeerService()
+	peerRootAddress := model.MustAddress("/peer")
+	_, err := wsv.PeerService(peerRootAddress)
 	assert.Error(t, err)
 
 	ps := []model.Peer{
@@ -64,11 +65,11 @@ func test_WSV(t *testing.T, wsv core.WSV) {
 		RandomPeer(),
 		RandomPeer(),
 	}
-	pids := []string{
-		":127.32.2.1",
-		":127.32.2.2",
-		":127.32.2.3",
-		":127.32.2.4",
+	pids := []model.Address{
+		model.MustAddress("p1@peer/peer"),
+		model.MustAddress("p2@peer/peer"),
+		model.MustAddress("p3@peer/peer"),
+		model.MustAddress("p4@peer/peer"),
 	}
 
 	for i, p := range ps {
@@ -76,7 +77,7 @@ func test_WSV(t *testing.T, wsv core.WSV) {
 	}
 	require.NoError(t, wsv.Commit())
 
-	peerService, err := wsv.PeerService()
+	peerService, err := wsv.PeerService(peerRootAddress)
 	assert.NoError(t, err)
 	assert.Equal(t, len(peerService.List()), 4)
 	exPs := ps

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -1,0 +1,70 @@
+package test_utils
+
+import (
+	"bytes"
+	"github.com/proskenion/proskenion/core/model"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func CastedHasher(o model.Hasher) model.Hasher {
+	return o
+}
+
+func CastedHasherPeerList(o []model.Peer) []model.Hasher {
+	ar := make([]model.Hasher, 0)
+	for _, c := range o {
+		ar = append(ar, CastedHasher(c))
+	}
+	return ar
+}
+
+func CastedHasherAccountList(o []model.Account) []model.Hasher {
+	ar := make([]model.Hasher, 0)
+	for _, c := range o {
+		ar = append(ar, CastedHasher(c))
+	}
+	return ar
+}
+
+func CastedHasherStorageList(o []model.Storage) []model.Hasher {
+	ar := make([]model.Hasher, 0)
+	for _, c := range o {
+		ar = append(ar, CastedHasher(c))
+	}
+	return ar
+}
+
+func AssertSetEqual(t *testing.T, actI interface{}, expI interface{}) {
+	act := make([]model.Hasher, 0)
+	exp := make([]model.Hasher, 0)
+
+	switch sl := actI.(type) {
+	case []model.Peer:
+		act = CastedHasherPeerList(sl)
+	case []model.Account:
+		act = CastedHasherAccountList(sl)
+	case []model.Storage:
+		act = CastedHasherStorageList(sl)
+	}
+
+	switch sl := expI.(type) {
+	case []model.Peer:
+		exp = CastedHasherPeerList(sl)
+	case []model.Account:
+		exp = CastedHasherAccountList(sl)
+	case []model.Storage:
+		exp = CastedHasherStorageList(sl)
+	}
+
+	assert.Equal(t, len(act), len(exp))
+	for i, ac := range act {
+		for i, ex := range exp {
+			if bytes.Equal(ac.Hash(), ex.Hash()) {
+				exp = append(exp[:i], exp[i+1:]...)
+				break
+			}
+		}
+		assert.Equalf(t, len(act)-i-1, len(exp), "assert hasher.", "%x is not found.", ac.Hash())
+	}
+}


### PR DESCRIPTION
# merkle patricia tree の修正
-  WSVで木をたどる順を “Storage名->domain名->アカウント名” に変更
-  MerklePatriciaTree に Range 検索クエリを追加
- model に Address interace を追加
- 伴い Command, Query processor を変更
- Storage, domain, Account の各 verify and parser を実装